### PR TITLE
Properly handle deletions with globalSecondaryIndex

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -220,8 +220,11 @@ Table.prototype.destroy = function (hashKey, rangeKey, options, callback) {
   callback = callback || function () {};
 
   if (_.isPlainObject(hashKey)) {
-    rangeKey = hashKey[self.schema.rangeKey] || null;
-    hashKey = hashKey[self.schema.hashKey];
+    rangeKey = null;
+    if (hashKey[self.schema.rangeKey] !== undefined){
+      rangeKey =  hashKey[self.schema.rangeKey];
+      hashKey = hashKey[self.schema.hashKey];
+    }
   }
 
   var params = {


### PR DESCRIPTION
Don't assume the table has a rangeKey set just because it has a hashKey set. It might have them defined in globalSecondaryIndex.